### PR TITLE
resolve #5 aws-serverless-prototypeを共有ディレクトリに設定する

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,6 +17,7 @@ Vagrant.configure("2") do |config|
 
   %w(
     aws-lambda-sample
+    aws-serverless-prototype
   ).each do |dir|
     config.vm.synced_folder "../#{dir}", "/home/vagrant/#{dir}" if  File.exist?("../#{dir}")
   end


### PR DESCRIPTION
## 完了の定義
- [aws-serverless-prototype](https://github.com/keita-nishimoto/aws-serverless-prototype) が共有ディレクトリに設定されている事