### PR TITLE
serverlessのバージョンを1.8系に上げる

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ AWS Lambdaのローカル開発環境です。
 以下がインストールされているミドルウェアの一覧です。
 
 - Node(v4.3.2)
-- serverless(1.6.0)
+- serverless(1.8.0)
 
 [ServerlessFramework](https://github.com/serverless/serverless)に関しては、開発がある程度安定するまでは最新版をインストールします。
 

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,6 +1,6 @@
 node_version: v4.3.2
 npm_version: 4.1.1
-yarn_version: 0.19.1
-serverless_version: 1.6.0
+yarn_version: 0.21.3
+serverless_version: 1.8.0
 dynamodb_download_url: http://dynamodb-local.s3-website-us-west-2.amazonaws.com/dynamodb_local_latest.tar.gz
 dynamodb_filename: dynamodb_local_latest.tar.gz


### PR DESCRIPTION
## 更新したパッケージ

- yarn 0.21.3
- serverless 1.8.0

## 関連リンク

- https://github.com/keita-nishimoto/aws-serverless-prototype/pull/105
- https://github.com/keita-nishimoto/aws-serverless-prototype/issues/82

これらと同時にマージする必要あり。